### PR TITLE
Add Enumerable design for Items and Abilities

### DIFF
--- a/Dota2GSI/Dota2GSI/Nodes/Abilities.cs
+++ b/Dota2GSI/Dota2GSI/Nodes/Abilities.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Dota2GSI.Nodes
 {
-    public class Abilities : Node
+    public class Abilities : Node, IEnumerable<Ability>
     {
         private List<Ability> abilities = new List<Ability>();
         public readonly Attributes Attributes;
@@ -42,9 +44,21 @@ namespace Dota2GSI.Nodes
             }
         }
 
+        public IEnumerator<Ability> GetEnumerator()
+        {
+            return this.abilities.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.abilities.GetEnumerator();
+        }
+
         public override string ToString()
         {
             return json;
         }
+
+        
     }
 }

--- a/Dota2GSI/Dota2GSI/Nodes/Items.cs
+++ b/Dota2GSI/Dota2GSI/Nodes/Items.cs
@@ -25,7 +25,7 @@ namespace Dota2GSI.Nodes
             get
             {
                 // Use ToList to make a copy, so original list is safe even when casted
-                return this.stash;
+                return this.stash.ToList();
             }
         }
 

--- a/Dota2GSI/Dota2GSI/Nodes/Items.cs
+++ b/Dota2GSI/Dota2GSI/Nodes/Items.cs
@@ -11,6 +11,24 @@ namespace Dota2GSI.Nodes
         public int CountInventory { get { return inventory.Count; } }
         public int CountStash { get { return stash.Count; } }
 
+        public IEnumerable<Item> Inventory
+        {
+            get
+            {
+                // Use ToList to make a copy, so original list is safe even when casted
+                return this.inventory.ToList();
+            }
+        }
+
+        public IEnumerable<Item> Stash
+        {
+            get
+            {
+                // Use ToList to make a copy, so original list is safe even when casted
+                return this.stash;
+            }
+        }
+
         internal Items(string json_data) : base(json_data)
         {
             List<string> slots = _ParsedData.Properties().Select(p => p.Name).ToList();
@@ -56,7 +74,7 @@ namespace Dota2GSI.Nodes
         /// <returns></returns>
         public bool InventoryContains(string itemname)
         {
-            foreach(Item inventory_item in this.inventory)
+            foreach (Item inventory_item in this.inventory)
             {
                 if (inventory_item.Name == itemname)
                 {


### PR DESCRIPTION
Currently there is no way to enumerate through the Items and Abilities, which hinder the .NET programming a lot (foreach, LINQ, IEnumerable<> extensions, etc...). This small change can make the development much quicker.
